### PR TITLE
* support copying tags

### DIFF
--- a/copy.php
+++ b/copy.php
@@ -257,6 +257,7 @@ try
 					$oP->add("</div>\n");
 				}
 				$aCurrentValues = array();
+				$aTagValues = array();
 				foreach (MetaModel::ListAttributeDefs(get_class($oObjToClone)) as $sAttCode => $oAttDef)
 				{
 					if (!$oAttDef->IsScalar()) continue;
@@ -274,13 +275,62 @@ try
 							$aCurrentValues[$sAttCode] = $oObjToClone->Get($sAttCode);
 						}
 					}
+					
+					if($oAttDef instanceof AttributeTagSet) {
+					
+						/** @var \ormTagSet $oSet Tag set */
+						$oSet = $oObjToClone->Get($sAttCode);
+						$aTagValues[$sAttCode] = $oSet->GetValues();
+						
+					}
+					
 				}
 				$sCurrentValues = json_encode($aCurrentValues);
+				$sTagValues = json_encode($aTagValues);
+				
+				$oP->add_script(
+<<<JS
+
+// Hack: add the tag set values as newly added
+// Selectize uses 'orig_value' to add the existing tags in the control. However, this leaves us with an empty 'added' array upon submit. Hence, interference is needed before submit.
+function TagFixer() {
+	
+	var aTagValues = $sTagValues;
+
+	Object.keys(aTagValues).forEach(function(sAttCode) {
+		
+		// Form submits attribute values from the DOM elements
+		// Update orig_value to empty and move remaining elements to added
+		
+		var sVal = $('#2_' + sAttCode).val();
+		var oVal = JSON.parse(sVal);
+		
+		// First obtain originally copied values that were not removed
+		var aNewAdded = $(oVal.orig_value).not(oVal.removed).get();
+		
+		// New values might have been added
+		aNewAdded = $.merge(aNewAdded, oVal.added);
+		
+		oVal.orig_value = [];
+		oVal.added = aNewAdded;
+		oVal.removed = [];
+		
+		$('#2_' + sAttCode).val(JSON.stringify(oVal));
+	
+	});
+	
+}
+
+JS
+				);
 
 				$oP->add_ready_script(
 					<<<EOF
 // Cancel => Back to details of the object we come from
 $('#form_2 button.cancel').click( function() { BackToDetails('$sSourceClass', $iSourceId, '')} );
+
+// Hack: call method to fix tags
+$('#form_2').attr('onsubmit', 'TagFixer(); ' + $('#form_2').attr('onsubmit'));
 
 // Hack: add the hidden (preset) fields into the Wizard Helper data (ajax autocomplete and widget reloads)
 oWizardHelper.ToJSON_original = oWizardHelper.ToJSON;


### PR DESCRIPTION
Tested on iTop 2.7; but not on iTop 3 (I think it will work though).

I added a similar hack to the existing ones to support tags.

Basically the main issue is that while you attempt to copy an object, the "orig_value" correctly gets set. In the GUI, it means tags are visible when creating a copy of an object (before confirmation). However, the elements are therefore not present in the "added" part. Resulting in the lack of tags when objects are created.

This implementation also allows adding/removing tags during the process (before clicking [Create]).

Basically right before submission, the value of the attribute gets rewritten:

* from the original attribute values, all the elements are kept which have not been removed by the user
* a combination of the above + tags added manually by the user is created
* orig_value and removed are both cleared
* added becomes the result of above 