### PR TITLE
Filter invalid rules

### DIFF
--- a/module.itop-object-copier.php
+++ b/module.itop-object-copier.php
@@ -17,6 +17,7 @@ SetupWebPage::AddModule(
         'dependencies' => array(),
         'mandatory' => false,
 		'visible' => true,
+		'installer' => iTopObjectCopierInstaller::class,
 
 		// Components
 		//
@@ -179,3 +180,36 @@ SetupWebPage::AddModule(
 		),
 	)
 );
+
+class iTopObjectCopierInstaller extends ModuleInstallerAPI
+{
+	/**
+	 * @inheritDoc
+	 */
+	public static function BeforeWritingConfig(Config $oConfiguration)
+	{
+		// Filter invalid rules
+		static::RemoveInvalidRules($oConfiguration);
+
+		return $oConfiguration;
+	}
+
+	/**
+	 * Walk over all predefined rules and remove the ones pointing to an invalid class
+	 *
+	 * @param Config $oConfig
+	 * @return void
+	 */
+	protected static function RemoveInvalidRules(Config &$oConfig)
+	{
+		/** @var array $aRules */
+		$aRules = $oConfig->GetModuleSetting('itop-object-copier', 'rules', []);
+
+		$aRules = array_filter($aRules, function ($aRule){
+			return MetaModel::IsValidClass($aRule['dest_class']);
+		});
+
+		$oConfig->SetModuleSetting('itop-object-copier', 'rules', $aRules);
+	}
+
+}


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Enhancement


## Objective

The default set of rules defined in the configuration includes rules for classes that not always exist in installations, depending on what you selected during setup.

This results in useless errors in the log on every page load, polluting the logs.

## Proposed solution

During setup, we can reduce the list of defined rules by removing the ones which apply to non existing classes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have tested all changes I made on an iTop instance
- [ ] Would a unit test be relevant and have I added it?
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?
