### PR TITLE
:bug: Fix AttributeCaseLog serialization when field is hidden or read-only

### DIFF
--- a/copy.php
+++ b/copy.php
@@ -289,6 +289,13 @@ try
 							// value for attribute AttributeTagSet is an ormTagSet, it needs to be converted to json manually
 							$aCurrentValues[$sAttCode] = $oAttDef->GetJsonForWidget($oObjToClone->Get($sAttCode));
 						}
+						else if ($oAttDef instanceof AttributeCaseLog)
+						{
+							// AttributeCaseLog returns an ormCaseLog object which is not JSON-serializable via json_encode.
+							// GetEditValue() returns only the pending (new) entry as a plain string, which is what
+							// the WizardHelper widget expects as current value.
+							$aCurrentValues[$sAttCode] = $oAttDef->GetEditValue($oObjToClone->Get($sAttCode));
+						}
 						else
 						{
 							$aCurrentValues[$sAttCode] = $oObjToClone->Get($sAttCode);


### PR DESCRIPTION
## Problem

When an `AttributeCaseLog` field has `OPT_ATT_HIDDEN` or `OPT_ATT_READONLY` flags set in the initial state (creation form), `copy.php` includes it in `$aCurrentValues` because `AttributeCaseLog::IsScalar()` returns `true` (inherited from `AttributeDBField`), so the `IsScalar()` guard does not filter it out.

The value returned by `DBObject::Get()` for a CaseLog field is an `ormCaseLog` object. `json_encode()` serializes this as an empty object `{}`, which is then injected into the WizardHelper's `m_oCurrentValues`. When the user triggers an AJAX reload (e.g. searching for a linked object), `ajax.render.php` receives this malformed value and fails to process it server-side.

## Fix

Handle `AttributeCaseLog` explicitly, analogous to the existing `AttributeTagSet` handling, by using `GetEditValue()` — which returns only the pending (new) entry as a plain string. This is the format the WizardHelper widget expects as current value, and works correctly both for empty logs (returns `""`) and when a preset entry exists via a copier rule.

## How to reproduce

1. Define a class with an `AttributeCaseLog` field
2. Set the field as `hidden` in the initial state flags
3. Use the Object Copier to open the creation form for that class
4. Trigger an AJAX reload (e.g. search for a linked external key object)
5. **Without fix:** error from `ajax.render.php` due to malformed `m_oCurrentValues`
6. **With fix:** form loads correctly